### PR TITLE
Fix: CitiesSplit recharts cursor dark theme

### DIFF
--- a/src/components/DataElement/CitiesSplit.jsx
+++ b/src/components/DataElement/CitiesSplit.jsx
@@ -29,6 +29,11 @@ export default function CitiesSplit({ isLoading, data }) {
               <XAxis type="number" hide />
               <Tooltip
                 formatter={value => [value, 'Liczba']}
+                contentStyle={{
+                  backgroundColor: theme.colors.backgroundPrimary,
+                  borderColor: theme.colors.backgroundTertiary,
+                }}
+                cursor={{ fill: theme.colors.backgroundTertiary }}
               />
               <Bar dataKey="count" fill={theme.colors.accent} />
             </BarChart>


### PR DESCRIPTION
![Screenshot from 2020-03-17 21-15-13](https://user-images.githubusercontent.com/2625371/76897846-cce17e80-6894-11ea-86cd-0f0dc1094236.png)
