### PR TITLE
Fix voivodeships view on the chart

### DIFF
--- a/src/components/DataElement/VoivodeshipsSplit.jsx
+++ b/src/components/DataElement/VoivodeshipsSplit.jsx
@@ -7,7 +7,7 @@ import Loader from "./Loader"
 import { useData } from '../../contexts/DataContext';
 
 export default function VoivodeshipsSplit({ isLoading, data }) {
-  const [, theme] = useStyletron();
+  const [css, theme] = useStyletron();
   const { setClickedVoivodeship } = useData();
 
   return (
@@ -23,7 +23,9 @@ export default function VoivodeshipsSplit({ isLoading, data }) {
           <BarChart
             data={data}
             layout="vertical"
-            className="voivodeship-charts"
+            className={css({
+              fontSize: '12px'
+            })}
           >
             <YAxis
               dataKey="voivodeship"

--- a/src/components/DataElement/VoivodeshipsSplit.jsx
+++ b/src/components/DataElement/VoivodeshipsSplit.jsx
@@ -15,8 +15,6 @@ export default function VoivodeshipsSplit({ isLoading, data }) {
       <Label3>Podział na województwa</Label3>
       <Block
         $style={{
-          height: '196px',
-          overflow: 'auto',
           margin: '12px 0 20px'
         }}
       >
@@ -25,6 +23,7 @@ export default function VoivodeshipsSplit({ isLoading, data }) {
           <BarChart
             data={data}
             layout="vertical"
+            className="voivodeship-charts"
           >
             <YAxis
               dataKey="voivodeship"
@@ -33,7 +32,7 @@ export default function VoivodeshipsSplit({ isLoading, data }) {
                 fill: theme.colors.contentPrimary,
                 cursor: 'pointer'
               }}
-              width={100}
+              width={130}
               onClick={({ value }) => setClickedVoivodeship(value)}
             />
             <XAxis type="number" hide />

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,10 @@ svg.marker text {
   font-weight: 500;
 }
 
+.voivodeship-charts {
+  font-size: 12px;
+}
+
 [data-theme=dark] *::-webkit-scrollbar {
   width: .35em;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -62,10 +62,6 @@ svg.marker text {
   font-weight: 500;
 }
 
-.voivodeship-charts {
-  font-size: 12px;
-}
-
 [data-theme=dark] *::-webkit-scrollbar {
   width: .35em;
 }


### PR DESCRIPTION
It's related to #37. What I've done here is:
* increase width voivodeships labels + decrease font size
* remove overflow scroll, which is not user friendly on mobile phones