### PR TITLE
Improve RWD layout for mobile: cases summary

### DIFF
--- a/src/components/Figures/Figures.jsx
+++ b/src/components/Figures/Figures.jsx
@@ -16,7 +16,6 @@ import ContentLoader from 'react-content-loader';
 import { useData } from '../../contexts/DataContext';
 import moment from 'moment';
 import { sum } from '../../helpers/misc';
-import useWindowDimensions from '../../hooks/window-dimensions';
 
 function CountLoader() {
   const [, theme] = useStyletron();
@@ -102,7 +101,6 @@ export default function Figures() {
   const { cases, deaths, cures, hospitalizations, quarantines, supervisions, tests, isLoading } = useData();
   const [showMore, setShowMore] = useState(false);
   const [, theme] = useStyletron();
-  const { width } = useWindowDimensions();
 
   return (
     <StyledCard

--- a/src/components/Layout/Mobile.jsx
+++ b/src/components/Layout/Mobile.jsx
@@ -36,7 +36,7 @@ function CustomTab(props) {
   );
 }
 
-const FlexGridItemCenterd = ({ children }) => {
+const FlexGridItemCentered = ({ children }) => {
   const [css] = useStyletron();
 
   return (
@@ -85,7 +85,7 @@ export default function Mobile() {
               justifyContent: 'space-arount'
             })}
           >
-            <FlexGridItemCenterd>
+            <FlexGridItemCentered>
               <Figure
                 data={deaths}
                 isLoading={isLoading}
@@ -93,8 +93,8 @@ export default function Mobile() {
                 color={theme.colors.primary}
                 size='compact'
               />
-            </FlexGridItemCenterd>
-            <FlexGridItemCenterd>
+            </FlexGridItemCentered>
+            <FlexGridItemCentered>
               <Figure
                 data={cases}
                 isLoading={isLoading}
@@ -102,8 +102,8 @@ export default function Mobile() {
                 color={theme.colors.negative}
                 size='compact'
               />
-            </FlexGridItemCenterd>
-            <FlexGridItemCenterd>
+            </FlexGridItemCentered>
+            <FlexGridItemCentered>
               <Figure
                 data={cures}
                 isLoading={isLoading}
@@ -111,7 +111,7 @@ export default function Mobile() {
                 color={theme.colors.positive}
                 size='compact'
               />
-            </FlexGridItemCenterd>
+            </FlexGridItemCentered>
           </div>
         </div>
 

--- a/src/components/Layout/Mobile.jsx
+++ b/src/components/Layout/Mobile.jsx
@@ -82,7 +82,7 @@ export default function Mobile() {
           <div
             className={css({
               display: 'flex',
-              justifyContent: 'space-arount'
+              justifyContent: 'space-around'
             })}
           >
             <FlexGridItemCentered>

--- a/src/components/Layout/Mobile.jsx
+++ b/src/components/Layout/Mobile.jsx
@@ -36,6 +36,23 @@ function CustomTab(props) {
   );
 }
 
+const FlexGridItemCenterd = ({ children }) => {
+  const [css] = useStyletron();
+
+  return (
+    <div
+      className={css({
+        display: 'flex',
+        width: '100%',
+        padding: '10px',
+        justifyContent: 'center'
+      })}
+    >
+      {children}
+    </div>
+  );
+};
+
 export default function Mobile() {
   const { cases, cures, deaths, hospitalizations, quarantines, supervisions, tests, isLoading } = useData();
   const { t, i18n } = useTranslation();
@@ -62,8 +79,13 @@ export default function Mobile() {
           })}
         >
           <HeadingSmall margin={0}>{t('coronavirusInPoland')}</HeadingSmall>
-          <FlexGrid flexGridColumnCount={3}>
-            <FlexGridItem>
+          <div
+            className={css({
+              display: 'flex',
+              justifyContent: 'space-arount'
+            })}
+          >
+            <FlexGridItemCenterd>
               <Figure
                 data={deaths}
                 isLoading={isLoading}
@@ -71,8 +93,8 @@ export default function Mobile() {
                 color={theme.colors.primary}
                 size='compact'
               />
-            </FlexGridItem>
-            <FlexGridItem>
+            </FlexGridItemCenterd>
+            <FlexGridItemCenterd>
               <Figure
                 data={cases}
                 isLoading={isLoading}
@@ -80,8 +102,8 @@ export default function Mobile() {
                 color={theme.colors.negative}
                 size='compact'
               />
-            </FlexGridItem>
-            <FlexGridItem>
+            </FlexGridItemCenterd>
+            <FlexGridItemCenterd>
               <Figure
                 data={cures}
                 isLoading={isLoading}
@@ -89,8 +111,8 @@ export default function Mobile() {
                 color={theme.colors.positive}
                 size='compact'
               />
-            </FlexGridItem>
-          </FlexGrid>
+            </FlexGridItemCenterd>
+          </div>
         </div>
 
         <Tabs

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { Map as LeafletMap, Marker, Popup, TileLayer, AttributionControl } from 'react-leaflet';
+import { Map as LeafletMap, Marker, Popup, TileLayer } from 'react-leaflet';
 import { divIcon } from 'leaflet';
 import { styled, useStyletron } from 'baseui';
 import MarkerClusterGroup from 'react-leaflet-markercluster';


### PR DESCRIPTION
In case of we have more cases, the layout for mobile started looking not good enough:
![IMG_64CDE38C3031-1](https://user-images.githubusercontent.com/18166552/77586813-14948580-6ee7-11ea-8f87-f6f23ffdf80c.jpeg)

I have made some improvements and now it's more responsive. Additionally I've fixed dev console warnings (from terminal) which are being showed during development.