### PR TITLE
Fix PWA installability on Desktop Chrome

### DIFF
--- a/public/manifest.dark.json
+++ b/public/manifest.dark.json
@@ -55,6 +55,11 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
+    },
+    {
+      "src": "images/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ],
   "splash_pages": null

--- a/public/manifest.light.json
+++ b/public/manifest.light.json
@@ -55,6 +55,11 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
+    },
+    {
+      "src": "images/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ],
   "splash_pages": null


### PR DESCRIPTION
Adds one max sized icon to support installability on Google Chrome Desktop version.