### PR TITLE
Data sources tab: visual improvements

### DIFF
--- a/src/components/Source/Source.jsx
+++ b/src/components/Source/Source.jsx
@@ -23,7 +23,7 @@ export default function Source() {
             maxHeight: '400px',
             overflow: 'auto',
             textAlign: 'left',
-            padding: '14px',
+            padding: '14px 0 0 0',
           },
         },
       }}

--- a/src/components/Source/Table.jsx
+++ b/src/components/Source/Table.jsx
@@ -59,6 +59,7 @@ export default function Table({ isLoading, data }) {
           borderColor: theme.colors.backgroundTertiary,
           marginTop: '12px',
           minHeight: '100px',
+          maxHeight: '350px'
         }}
       >
         {isLoading && (


### PR DESCRIPTION
I've changed two things in data source tab:
1. sticky table header, search box is visible during scrolling the data
2. decrease tab panel paddings to improve readability, especially on mobile devices

<img width="466" alt="data-source" src="https://user-images.githubusercontent.com/18166552/77967012-818f8d00-72e4-11ea-8966-cb2eb63cabcf.png">
