### PR TITLE
[#76] Fixes numbers don't fit on screen anymore in mobile view

### DIFF
--- a/src/components/Layout/Mobile.jsx
+++ b/src/components/Layout/Mobile.jsx
@@ -72,8 +72,7 @@ export default function Mobile() {
         <div
           className={css({
             backgroundColor: theme.colors.backgroundPrimary,
-            padding: theme.sizing.scale600,
-            paddingBottom: 0,
+            padding: `${theme.sizing.scale600} 0 0 0`,
           })}
         >
           <div
@@ -82,6 +81,7 @@ export default function Mobile() {
               flexWrap: 'nowrap',
               justifyContent: 'space-between',
               alignItems: 'center',
+              padding: `0 ${theme.sizing.scale600}`,
             })}
           >
             <HeadingSmall margin={0}>{t('coronavirusInPoland')}</HeadingSmall>
@@ -158,7 +158,10 @@ export default function Mobile() {
           <div
             className={css({
               display: 'flex',
-              justifyContent: 'space-around',
+              justifyContent: 'flex-start',
+              overflow: 'auto',
+              flex: 1,
+              padding: `0 ${theme.sizing.scale600}`,
             })}
           >
             <FlexGridItemCentered>
@@ -272,7 +275,14 @@ export default function Mobile() {
                 height: 'auto',
               })}
             >
-              <FlexGrid flexGridColumnCount={2}>
+              <FlexGrid
+                flexGridColumnCount={2}
+                className={css({
+                  margin: `0 -${theme.sizing.scale600}`,
+                  padding: `0 ${theme.sizing.scale600}`,
+                  overflowX: 'auto',
+                  flex: 1,
+                })}>
                 <FlexGridItem>
                   <Figure
                     data={hospitalizations}


### PR DESCRIPTION
Added overflow-x to the header figures to allow user to scroll to view the numbers.
Added overflow-x statistics figures to allow to allow user to scroll to view the numbers without scrolling the whole view.